### PR TITLE
Python2 cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,10 @@ OMERO Prometheus Exporter
 [![Actions Status](https://github.com/ome/ansible-role-omero-prometheus-exporter/workflows/Molecule/badge.svg)](https://github.com/ome/ansible-role-omero-prometheus-exporter/actions)
 [![Ansible Role](https://img.shields.io/ansible/role/41332.svg)](https://galaxy.ansible.com/ome/omero_prometheus_exporter/)
 
-OMERO Prometheus exporter.
-
 Configures services for exporting prometheus-compatible metrics from OMERO.server.
 Uses the OMERO API, so can be run remotely from OMERO.
 
-See https://github.com/IDR/omero-prometheus-tools
+See https://github.com/ome/omero-prometheus-tools
 
 Note: metric endpoints are not authenticated.
 
@@ -18,10 +16,13 @@ Role Variables
 --------------
 
 Required:
+
 - `omero_prometheus_exporter_omero_user`: OMERO user (a read-only light admin)
 - `omero_prometheus_exporter_omero_password`: OMERO user password
 
 Optional:
+
+- `omero_prometheus_tools_version`: version of the OMERO monitoring tool, default `0.2.3`
 - `omero_prometheus_exporter_omero_host`: OMERO server, default `localhost`
 - `omero_prometheus_exporter_system_user`: System account for running services
 - `omero_prometheus_exporter_port`: Publish metrics on this port, default `9449`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -30,7 +30,7 @@ omero_prometheus_exporter_counts_query_files:
 ######################################################################
 
 # Prometheus component versions
-omero_prometheus_tools_version: 0.2.2
+omero_prometheus_tools_version: 0.2.3
 
 omero_prometheus_tools_requirements_ice_package:
   RedHat: "https://github.com/ome/zeroc-ice-py-centos7/releases/download/\

--- a/molecule/default/Dockerfile.j2
+++ b/molecule/default/Dockerfile.j2
@@ -14,9 +14,9 @@ ENV {{ var }} {{ value }}
 {% endfor %}
 {% endif %}
 
-RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 && apt-get clean; \
-    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install python sudo python-devel python*-dnf bash iproute && dnf clean all; \
-    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y python sudo yum-plugin-ovl bash iproute ca-certificates && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
+RUN if [ $(command -v apt-get) ]; then apt-get update && apt-get install -y python sudo bash ca-certificates iproute2 python-apt aptitude && apt-get clean; \
+    elif [ $(command -v dnf) ]; then dnf makecache && dnf --assumeyes install /usr/bin/python3 /usr/bin/python3-config /usr/bin/dnf-3 sudo bash iproute && dnf clean all; \
+    elif [ $(command -v yum) ]; then yum makecache fast && yum install -y /usr/bin/python /usr/bin/python2-config sudo yum-plugin-ovl bash iproute ca-certificates && sed -i 's/plugins=0/plugins=1/g' /etc/yum.conf && yum clean all; \
     elif [ $(command -v zypper) ]; then zypper refresh && zypper install -y python sudo bash python-xml iproute2 && zypper clean -a; \
     elif [ $(command -v apk) ]; then apk update && apk add --no-cache python sudo bash ca-certificates; \
     elif [ $(command -v xbps-install) ]; then xbps-install -Syu && xbps-install -y python sudo bash ca-certificates iproute2 && xbps-remove -O; fi

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -43,6 +43,18 @@
   notify:
     - restart prometheus-omero-exporter
 
+- name: omero prometheus exporter | delete Python 2 installation directories
+  become: true
+  file:
+    name: "/opt/prometheus-omero-tools/{{ item }}"
+    state: absent
+  with_items:
+    - bin
+    - etc
+    - include
+    - lib
+    - lib64
+
 - name: omero prometheus exporter | configure service
   become: true
   template:


### PR DESCRIPTION
Discovered during the review of https://github.com/ome/omero-prometheus-tools/pull/13

Deployments which have been upgraded from `ome.omero_prometheus_exporter 0.2.x` to `ome.omero_prometheus_exporter 0.3.x` still contain the former Python 2 directories alongside the Python 3 virtual environment. This can lead to confusion.

3de5843dba33714e83313e2054f2378dd1c0c992 proposes to address this by cleaning the Python 2 directories as part of the role
aaa4d47966b20dc2b5d129bd82d229c049f599dd also upgrades the version of `omero_prometheus_tools` and updates the README to make it clear that the library version can be updated via role variable