### PR TITLE
Install more recent versions of OMERO.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ OMERO Prometheus Exporter
 
 Configures services for exporting prometheus-compatible metrics from OMERO.server.
 Uses the OMERO API, so can be run remotely from OMERO.
+Requires the OMERO.server to be configured with a certificate
 
 See https://github.com/ome/omero-prometheus-tools
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,5 +43,5 @@ omero_prometheus_tools_requirements:
   # TODO: make the use of our non-standard wheel optional
   - "{{ omero_prometheus_tools_requirements_ice_package[ansible_os_family] |
         default('zeroc-ice')}}"
-  - omero-py==5.6.0
+  - omero-py>=5.6.0
   - "omero-prometheus-tools=={{ omero_prometheus_tools_version }}"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -43,5 +43,5 @@ omero_prometheus_tools_requirements:
   # TODO: make the use of our non-standard wheel optional
   - "{{ omero_prometheus_tools_requirements_ice_package[ansible_os_family] |
         default('zeroc-ice')}}"
-  - omero-py>=5.6.0
+  - omero-py>=5.13.0
   - "omero-prometheus-tools=={{ omero_prometheus_tools_version }}"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -13,6 +13,7 @@
           databases: [omero]
 
     - role: ome.omero_server
+      omero_server_selfsigned_certificates: true
 
     - role: ome.omero_prometheus_exporter
       omero_prometheus_exporter_omero_user: root


### PR DESCRIPTION
This relaxes the pinning of the OMERO.py version to allow the Prometheus exporter to keep connecting to OMERO.server instances with the latest security protocol enhancements. Without this change, the createSession() will fail Connection reset by peer and the metrics endpoint returns a `Connection refused`

This was discovered in the context of https://github.com/ome/omero-certificates/pull/38#pullrequestreview-1626402135. After running the latest `omero certificates` command, the monitoring endpoint started failing for this instance. Locally, this got resolved by running

```
[sbesson@test120-omeroreadonly-2 prometheus-omero-tools]$ sudo /opt/prometheus-omero-tools/venv3/bin/pip install -U omero-py
[sbesson@test120-omeroreadonly-2 prometheus-omero-tools]$ sudo systemctl restart prometheus-omero-exporter
```

A patch release of the role will be required in order for the monitoring of next IDR deployments to remain functional with `omero-certificates 0.3.0`. Note also the Molecule CI is failing and might need to be fixed separately or as a prerequisite @pwalczysko and @khaledk2 