### PR TITLE
Update framework

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -48,16 +48,8 @@ jobs:
       - test
     runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - name: Read the role name
-        id: role-name
-        run: |
-          name=$(grep 'role_name' meta/main.yml)
-          name=$(echo $name | sed -r 's/^[^:]*:(.*)$/\1/' | tr -d '[:space:]')
-          echo "rolename=$name" >> "$GITHUB_OUTPUT"
-      - name: Publish to Galaxy
-        uses: ome/action-ansible-galaxy-publish@main
+      - name: galaxy
+        uses: ansible-actions/ansible-galaxy-action@v1.2.0
         with:
-          galaxy-api-key: ${{ secrets.GALAXY_API_KEY }}
-          galaxy-version: ${{ github.ref_name }}
-          role-name: ${{ steps.role-name.outputs.rolename }}
+          galaxy_api_key: ${{ secrets.GALAXY_API_KEY }}
+          galaxy_version: ${{  github.ref_name }}

--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -10,7 +10,7 @@ on:
 jobs:
 
   list-scenarios:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       matrix: ${{ steps.listscenarios.outputs.scenarios }}
     steps:
@@ -22,7 +22,7 @@ jobs:
     name: Test
     needs:
       - list-scenarios
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       # Keep running so we can see if other tests pass
       fail-fast: false
@@ -30,13 +30,13 @@ jobs:
         scenario: ${{fromJson(needs.list-scenarios.outputs.matrix)}}
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
       - name: Install Ansible & Molecule
         run: |
-            pip install "ansible<8" "ansible-lint<6.13" flake8
-            pip install "molecule<5" "ansible-compat<4"
+            pip install "requests" "ansible" "ansible-lint" "flake8"
+            pip install "molecule" "ansible-compat"
             pip install molecule-plugins[docker] pytest-testinfra
       - name: Run molecule
         run: molecule test -s "${{ matrix.scenario }}"
@@ -46,7 +46,7 @@ jobs:
     if: startsWith(github.ref, 'refs/tags')
     needs:
       - test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: Read the role name

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Required:
 
 Optional:
 
+Python3:
+- `python_version`: Variable used in the `ansible-role-python3-virtualenv` and for the `omero_prometheus_tools_requirements_ice_package`. Use this variable for omero-server, omero-web and omero-prometheus-exporter to upgrade/downgrade the python version in the virtualenvs the server/web/prometheus-exporter are running in. Default is `"3.12"`. Supported versions are `"3.12"`, `"3.11"`.
+
 - `omero_prometheus_tools_version`: version of the OMERO monitoring tool, default `0.2.3`
 - `omero_prometheus_exporter_omero_host`: OMERO server, default `localhost`
 - `omero_prometheus_exporter_system_user`: System account for running services

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Required:
 Optional:
 
 Python3:
-- `python_version`: Variable used in the `ansible-role-python3-virtualenv` and for the `omero_prometheus_tools_requirements_ice_package`. Use this variable for omero-server, omero-web and omero-prometheus-exporter to upgrade/downgrade the python version in the virtualenvs the server/web/prometheus-exporter are running in. Default is `"3.12"`. Supported versions are `"3.12"`, `"3.11"`.
+- `python_version`: Variable used in the `ansible-role-python3-virtualenv` and for the `omero_prometheus_tools_requirements_ice_package`. Use this variable for omero-server, omero-web and omero-prometheus-exporter to upgrade/downgrade the python version in the virtual environment(s) the server/web/prometheus-exporter is(are)running in. Default is `"3.12"`, see the `ansible-role-python3-virtualenv`  for the full list of supported Python versions.
 
 - `omero_prometheus_tools_version`: version of the OMERO monitoring tool, default `0.2.3`
 - `omero_prometheus_exporter_omero_host`: OMERO server, default `localhost`

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -32,16 +32,21 @@ omero_prometheus_exporter_counts_query_files:
 # Prometheus component versions
 omero_prometheus_tools_version: 0.2.3
 
-omero_prometheus_tools_requirements_ice_package:
-  RedHat: "https://github.com/glencoesoftware/zeroc-ice-py-rhel9-x86_64/releases/download/\
-      20230830/zeroc_ice-3.6.5-cp39-cp39-linux_x86_64.whl"
-  Debian: "https://github.com/glencoesoftware/zeroc-ice-py-ubuntu2204-x86_64/releases/download/\
-      20221004/zeroc_ice-3.6.5-cp310-cp310-linux_x86_64.whl"
+omero_prometheus_tools_requirements_ice_package: "https://github.com/glencoesoftware/zeroc-ice-py-linux-x86_64/releases/download/20240202/zeroc_ice-3.6.5-cp{{ omero_prometheus_tools_python_version }}-cp{{ omero_prometheus_tools_python_version }}-manylinux_2_28_x86_64.whl"
+
+
+# Variable used in the ansible-role-python3-virtualenv and for the
+# omero_web_python_requirements_ice_package. Use the same variable
+# (python_version) for both omero-server and omero-web.
+python_version: "3.12"
+
+# Derived variable used in the omero_server_python_requirements_ice_package
+omero_prometheus_tools_python_version: "{{ python_version | replace('.', '') }}"
 
 # List of python3 packages to install
 omero_prometheus_tools_requirements:
   # TODO: make the use of our non-standard wheel optional
-  - "{{ omero_prometheus_tools_requirements_ice_package[ansible_os_family] |
+  - "{{ omero_prometheus_tools_requirements_ice_package |
         default('zeroc-ice')}}"
   - omero-py>=5.18.0
   - "omero-prometheus-tools=={{ omero_prometheus_tools_version }}"

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,7 +3,7 @@
 
 - name: restart prometheus-omero-exporter
   become: true
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
     enabled: true
     name: prometheus-omero-exporter

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -4,7 +4,7 @@ galaxy_info:
   description: OMERO Prometheus exporter
   company: Open Microscopy Environment
   license: BSD
-  min_ansible_version: 2.10
+  min_ansible_version: 2.11
   platforms:
     - name: EL
       versions:

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   roles:
 
-    - role: ome.postgresql
+    - role: postgresql
       postgresql_install_server: true
       postgresql_databases:
         - name: omero
@@ -12,7 +12,7 @@
           password: omero
           databases: [omero]
 
-    - role: ome.omero_server
+    - role: omero_server
       omero_server_selfsigned_certificates: true
 
     - role: ome.omero_prometheus_exporter
@@ -20,4 +20,4 @@
       omero_prometheus_exporter_omero_password: omero
 
   vars:
-    postgresql_version: "14"
+    postgresql_version: "16"

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -7,6 +7,7 @@
       postgresql_install_server: true
       postgresql_databases:
         - name: omero
+          owner: omero
       postgresql_users:
         - user: omero
           password: omero

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -3,7 +3,7 @@
   hosts: all
   roles:
 
-    - role: postgresql
+    - role: ome.postgresql
       postgresql_install_server: true
       postgresql_databases:
         - name: omero

--- a/molecule/default/playbook.yml
+++ b/molecule/default/playbook.yml
@@ -13,7 +13,7 @@
           password: omero
           databases: [omero]
 
-    - role: omero_server
+    - role: ome.omero_server
       omero_server_selfsigned_certificates: true
 
     - role: ome.omero_prometheus_exporter

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,8 +1,4 @@
 ---
-# Remove when the requirements are released !
-- src: ome.postgresql
 
-# - src: ome.omero_server
-- name: omero_server
-  src: https://github.com/pwalczysko/ansible-role-omero-server
-  version: pythonvers-symlink-in-virtualenvrole
+- src: ome.postgresql
+- src: ome.omero_server

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,9 +1,7 @@
 ---
 # Remove when the requirements are released !
-# - src: ome.postgresql
-- name: postgresql
-  src: https://github.com/pwalczysko/ansible-role-postgresql
-  version: p312
+- src: ome.postgresql
+
 # - src: ome.omero_server
 - name: omero_server
   src: https://github.com/pwalczysko/ansible-role-omero-server

--- a/molecule/default/requirements.yml
+++ b/molecule/default/requirements.yml
@@ -1,3 +1,10 @@
 ---
-- src: ome.postgresql
-- src: ome.omero_server
+# Remove when the requirements are released !
+# - src: ome.postgresql
+- name: postgresql
+  src: https://github.com/pwalczysko/ansible-role-postgresql
+  version: p312
+# - src: ome.omero_server
+- name: omero_server
+  src: https://github.com/pwalczysko/ansible-role-omero-server
+  version: pythonvers-symlink-in-virtualenvrole

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,14 +4,14 @@
 # TODO: Move to a separate role?
 - name: omero prometheus exporter | create system user
   become: true
-  user:
+  ansible.builtin.user:
     name: "{{ omero_prometheus_exporter_system_user }}"
     state: present
     system: true
 
 - name: omero prometheus exporter | setup virtualenv3
   become: true
-  pip:
+  ansible.builtin.pip:
     name: "pip>=21"
     state: present
     virtualenv: /opt/prometheus-omero-tools/venv3
@@ -19,7 +19,7 @@
 
 - name: omero prometheus exporter | install omero-prometheus-tools
   become: true
-  pip:
+  ansible.builtin.pip:
     name: "{{ omero_prometheus_tools_requirements }}"
     state: present
     virtualenv: /opt/prometheus-omero-tools/venv3
@@ -29,7 +29,7 @@
 
 - name: omero prometheus exporter | delete Python 2 installation directories
   become: true
-  file:
+  ansible.builtin.file:
     name: "/opt/prometheus-omero-tools/{{ item }}"
     state: absent
   with_items:
@@ -41,7 +41,7 @@
 
 - name: omero prometheus exporter | configure service
   become: true
-  template:
+  ansible.builtin.template:
     dest: "{{ systemd_prometheus_omero_exporter_env_file_path }}"
     src: sysconfig-prometheus-omero-exporter.j2
     owner: "{{ omero_prometheus_exporter_system_user }}"
@@ -52,7 +52,7 @@
 
 - name: omero prometheus exporter | install service
   become: true
-  template:
+  ansible.builtin.template:
     dest: /etc/systemd/system/prometheus-omero-exporter.service
     src: systemd-prometheus-omero-exporter-service.j2
     mode: 0644
@@ -61,7 +61,7 @@
 
 - name: omero prometheus exporter | enable service
   become: true
-  systemd:
+  ansible.builtin.systemd:
     daemon_reload: true
     enabled: true
     name: prometheus-omero-exporter


### PR DESCRIPTION
1. Update framework
2. Add ability to choose ``python_version`` similarly to ``omero-server`` and ``omero-web`` (see README for explanation)
3. Bump postgresql version to 16

Note: Changes in the requirements file were necessary to make the build pass (install omero-server and postgresql roles from branches) - these need to be reverted before merging